### PR TITLE
fix: Qt版本与多平台编译兼容性问题修复并添加xmake构建配置

### DIFF
--- a/src/core/qwt_color_cycle.h
+++ b/src/core/qwt_color_cycle.h
@@ -12,6 +12,7 @@
 
 #include "qwtcore_global.h"
 #include <qcolor.h>
+#include <qvector.h>
 
 #if QT_VERSION < 0x060000
 template< typename T >

--- a/src/core/qwt_colormap_preset.cpp
+++ b/src/core/qwt_colormap_preset.cpp
@@ -222,7 +222,7 @@ QVector< QPair< double, QColor > > QwtColorMapPreset::colorStops(Preset preset)
  */
 std::unique_ptr< QwtLinearColorMap > QwtColorMapPreset::create(Preset preset)
 {
-    auto map         = std::make_unique< QwtLinearColorMap >();
+    auto map         = qwt_make_unique< QwtLinearColorMap >();
     const auto stops = colorStops(preset);
     if (stops.isEmpty())
         return map;

--- a/src/core/qwt_interval.h
+++ b/src/core/qwt_interval.h
@@ -60,8 +60,8 @@ public:
     //! Border flags
     Q_DECLARE_FLAGS(BorderFlags, BorderFlag)
 
-    constexpr QwtInterval() noexcept;
-    constexpr QwtInterval(double minValue, double maxValue, BorderFlags = IncludeBorders) noexcept;
+    Q_DECL_CONSTEXPR QwtInterval() noexcept;
+    Q_DECL_CONSTEXPR QwtInterval(double minValue, double maxValue, BorderFlags = IncludeBorders) noexcept;
 
     // Assign the limits of the interval
     void setInterval(double minValue, double maxValue, BorderFlags = IncludeBorders) noexcept;
@@ -79,14 +79,14 @@ public:
     bool operator!=(const QwtInterval&) const;
 
     void setBorderFlags(BorderFlags) noexcept;
-    constexpr BorderFlags borderFlags() const noexcept;
+    Q_DECL_CONSTEXPR BorderFlags borderFlags() const noexcept;
 
-    constexpr double minValue() const noexcept;
-    constexpr double maxValue() const noexcept;
-    constexpr double centerValue() const noexcept;
+    Q_DECL_CONSTEXPR double minValue() const noexcept;
+    Q_DECL_CONSTEXPR double maxValue() const noexcept;
+    Q_DECL_CONSTEXPR double centerValue() const noexcept;
 
-    constexpr double width() const noexcept;
-    constexpr long double widthL() const noexcept;
+    Q_DECL_CONSTEXPR double width() const noexcept;
+    Q_DECL_CONSTEXPR long double widthL() const noexcept;
 
     void setMinValue(double) noexcept;
     void setMaxValue(double) noexcept;
@@ -120,8 +120,8 @@ public:
     // Extend an interval with a value
     QwtInterval& operator|=(double);
 
-    constexpr bool isValid() const noexcept;
-    constexpr bool isNull() const noexcept;
+    Q_DECL_CONSTEXPR bool isValid() const noexcept;
+    Q_DECL_CONSTEXPR bool isNull() const noexcept;
     void invalidate() noexcept;
 
     // Symmetrize the interval around a value
@@ -142,7 +142,7 @@ Q_DECLARE_TYPEINFO(QwtInterval, Q_MOVABLE_TYPE);
  * @details Creates an invalid interval [0.0, -1.0]
  * @sa setInterval(), isValid()
  */
-inline constexpr QwtInterval::QwtInterval() noexcept : m_minValue(0.0), m_maxValue(-1.0), m_borderFlags(IncludeBorders)
+inline Q_DECL_CONSTEXPR QwtInterval::QwtInterval() noexcept : m_minValue(0.0), m_maxValue(-1.0), m_borderFlags(IncludeBorders)
 {
 }
 
@@ -152,7 +152,7 @@ inline constexpr QwtInterval::QwtInterval() noexcept : m_minValue(0.0), m_maxVal
  * @param maxValue Maximum value
  * @param borderFlags Include/Exclude borders
  */
-inline constexpr QwtInterval::QwtInterval(double minValue, double maxValue, BorderFlags borderFlags) noexcept
+inline Q_DECL_CONSTEXPR QwtInterval::QwtInterval(double minValue, double maxValue, BorderFlags borderFlags) noexcept
     : m_minValue(minValue), m_maxValue(maxValue), m_borderFlags(borderFlags)
 {
 }
@@ -184,7 +184,7 @@ inline void QwtInterval::setBorderFlags(BorderFlags borderFlags) noexcept
  * @return Border flags
  * @sa setBorderFlags()
  */
-inline constexpr QwtInterval::BorderFlags QwtInterval::borderFlags() const noexcept
+inline Q_DECL_CONSTEXPR QwtInterval::BorderFlags QwtInterval::borderFlags() const noexcept
 {
     return m_borderFlags;
 }
@@ -211,7 +211,7 @@ inline void QwtInterval::setMaxValue(double maxValue) noexcept
  * @return Minimum value of the interval
  * @sa setMinValue()
  */
-inline constexpr double QwtInterval::minValue() const noexcept
+inline Q_DECL_CONSTEXPR double QwtInterval::minValue() const noexcept
 {
     return m_minValue;
 }
@@ -220,7 +220,7 @@ inline constexpr double QwtInterval::minValue() const noexcept
  * @return Maximum value of the interval
  * @sa setMaxValue()
  */
-inline constexpr double QwtInterval::maxValue() const noexcept
+inline Q_DECL_CONSTEXPR double QwtInterval::maxValue() const noexcept
 {
     return m_maxValue;
 }
@@ -229,7 +229,7 @@ inline constexpr double QwtInterval::maxValue() const noexcept
  * @return Center of the interval
  * @sa width()
  */
-inline constexpr double QwtInterval::centerValue() const noexcept
+inline Q_DECL_CONSTEXPR double QwtInterval::centerValue() const noexcept
 {
     return isValid() ? (m_minValue + (m_maxValue - m_minValue) * 0.5) : 0.0;
 }
@@ -241,7 +241,7 @@ inline constexpr double QwtInterval::centerValue() const noexcept
  * @return True, if the interval is valid
  * @sa isValid()
  */
-inline constexpr bool QwtInterval::isValid() const noexcept
+inline Q_DECL_CONSTEXPR bool QwtInterval::isValid() const noexcept
 {
     return ((m_borderFlags & ExcludeBorders) == 0) ? (m_minValue <= m_maxValue) : (m_minValue < m_maxValue);
 }
@@ -252,7 +252,7 @@ inline constexpr bool QwtInterval::isValid() const noexcept
  * @return Interval width
  * @sa isValid()
  */
-inline constexpr double QwtInterval::width() const noexcept
+inline Q_DECL_CONSTEXPR double QwtInterval::width() const noexcept
 {
     return isValid() ? (m_maxValue - m_minValue) : 0.0;
 }
@@ -264,7 +264,7 @@ inline constexpr double QwtInterval::width() const noexcept
  * @return Interval width
  * @sa isValid()
  */
-inline constexpr long double QwtInterval::widthL() const noexcept
+inline Q_DECL_CONSTEXPR long double QwtInterval::widthL() const noexcept
 {
     return isValid() ? static_cast< long double >(m_maxValue) - static_cast< long double >(m_minValue) : 0.0L;
 }
@@ -326,7 +326,7 @@ inline QwtInterval QwtInterval::operator|(double value) const
  * @brief Check if interval is null
  * @return True if isValid() && (minValue() >= maxValue())
  */
-inline constexpr bool QwtInterval::isNull() const noexcept
+inline Q_DECL_CONSTEXPR bool QwtInterval::isNull() const noexcept
 {
     return isValid() && m_minValue >= m_maxValue;
 }

--- a/src/core/qwt_scale_map.h
+++ b/src/core/qwt_scale_map.h
@@ -74,19 +74,19 @@ public:
     double invTransform(double p) const;
 
     //! Return first border of paint interval
-    constexpr double p1() const noexcept;
+    Q_DECL_CONSTEXPR double p1() const noexcept { return m_p1; }
     //! Return second border of paint interval
-    constexpr double p2() const noexcept;
+    Q_DECL_CONSTEXPR double p2() const noexcept { return m_p2; }
 
     //! Return first border of scale interval
-    constexpr double s1() const noexcept;
+    Q_DECL_CONSTEXPR double s1() const noexcept { return m_s1; }
     //! Return second border of scale interval
-    constexpr double s2() const noexcept;
+    Q_DECL_CONSTEXPR double s2() const noexcept { return m_s2; }
 
     //! Return distance between paint interval boundaries
-    double pDist() const;
+    double pDist() const { return qAbs(m_p2 - m_p1); }
     //! Return distance between scale interval boundaries
-    double sDist() const;
+    double sDist() const { return qAbs(m_s2 - m_s1); }
 
     //! Transform a rectangle from scale to paint coordinates
     static QRectF transform(const QwtScaleMap&, const QwtScaleMap&, const QRectF&);
@@ -104,16 +104,16 @@ public:
     static bool isLinerScale(const QwtScaleMap& sm);
 
     //! Check if this scale has no nonlinear transformation
-    constexpr bool isLinear() const noexcept;
+    Q_DECL_CONSTEXPR bool isLinear() const noexcept { return m_transform == nullptr; }
 
     //! Check if the mapping direction is inverted
-    constexpr bool isInverting() const noexcept;
+    Q_DECL_CONSTEXPR bool isInverting() const noexcept { return ((m_p1 < m_p2) != (m_s1 < m_s2)); }
 
     //! Conversion factor for linear fast-path: result = p1() + (value - ts1()) * cnv()
-    constexpr double cnv() const noexcept;
+    Q_DECL_CONSTEXPR double cnv() const noexcept { return m_cnv; }
 
     //! Transformed scale origin for linear fast-path
-    constexpr double ts1() const noexcept;
+    Q_DECL_CONSTEXPR double ts1() const noexcept { return m_ts1; }
 
 protected:
     void swap(QwtScaleMap& other) noexcept;  // helper
@@ -128,54 +128,6 @@ private:
 
     QwtTransform* m_transform { nullptr };
 };
-
-/**
- * @brief Return first border of the scale interval
- */
-inline constexpr double QwtScaleMap::s1() const noexcept
-{
-    return m_s1;
-}
-
-/**
- * @brief Return second border of the scale interval
- */
-inline constexpr double QwtScaleMap::s2() const noexcept
-{
-    return m_s2;
-}
-
-/**
- * @brief Return first border of the paint interval
- */
-inline constexpr double QwtScaleMap::p1() const noexcept
-{
-    return m_p1;
-}
-
-/**
- * @brief Return second border of the paint interval
- */
-inline constexpr double QwtScaleMap::p2() const noexcept
-{
-    return m_p2;
-}
-
-/**
- * @brief Return qwtAbs(p2() - p1())
- */
-inline double QwtScaleMap::pDist() const
-{
-    return qAbs(m_p2 - m_p1);
-}
-
-/**
- * @brief Return qwtAbs(s2() - s1())
- */
-inline double QwtScaleMap::sDist() const
-{
-    return qAbs(m_s2 - m_s1);
-}
 
 /**
  * @brief Transform a point related to the scale interval into a point related to the paint device interval
@@ -204,30 +156,6 @@ inline double QwtScaleMap::invTransform(double p) const
         s = m_transform->invTransform(s);
 
     return s;
-}
-
-//! Return true when ( p1() < p2() ) != ( s1() < s2() )
-inline constexpr bool QwtScaleMap::isInverting() const noexcept
-{
-    return ((m_p1 < m_p2) != (m_s1 < m_s2));
-}
-
-//! Return true when there is no nonlinear transformation
-inline constexpr bool QwtScaleMap::isLinear() const noexcept
-{
-    return m_transform == nullptr;
-}
-
-//! Return the conversion factor for linear fast-path transform
-inline constexpr double QwtScaleMap::cnv() const noexcept
-{
-    return m_cnv;
-}
-
-//! Return the transformed scale origin for linear fast-path transform
-inline constexpr double QwtScaleMap::ts1() const noexcept
-{
-    return m_ts1;
 }
 
 #ifndef QT_NO_DEBUG_STREAM

--- a/src/plot/qwt_axis.h
+++ b/src/plot/qwt_axis.h
@@ -63,25 +63,25 @@ enum
     AxisPositions = XTop + 1
 };
 
-constexpr bool isValid(int axisPos) noexcept;
-constexpr bool isYAxis(int axisPos) noexcept;
-constexpr bool isXAxis(int axisPos) noexcept;
+Q_DECL_CONSTEXPR bool isValid(int axisPos) noexcept;
+Q_DECL_CONSTEXPR bool isYAxis(int axisPos) noexcept;
+Q_DECL_CONSTEXPR bool isXAxis(int axisPos) noexcept;
 }
 
 // Return true, when axisPos is in the valid range [ YLeft, XTop ]
-inline constexpr bool QwtAxis::isValid(int axisPos) noexcept
+inline Q_DECL_CONSTEXPR bool QwtAxis::isValid(int axisPos) noexcept
 {
     return (axisPos >= 0 && axisPos < AxisPositions);
 }
 
 // Return true, when axisPos is XBottom or XTop
-inline constexpr bool QwtAxis::isXAxis(int axisPos) noexcept
+inline Q_DECL_CONSTEXPR bool QwtAxis::isXAxis(int axisPos) noexcept
 {
     return (axisPos == XBottom) || (axisPos == XTop);
 }
 
 // Return true, when axisPos is YLeft or YRight
-inline constexpr bool QwtAxis::isYAxis(int axisPos) noexcept
+inline Q_DECL_CONSTEXPR bool QwtAxis::isYAxis(int axisPos) noexcept
 {
     return (axisPos == YLeft) || (axisPos == YRight);
 }

--- a/src/plot/qwt_plot.cpp
+++ b/src/plot/qwt_plot.cpp
@@ -2129,7 +2129,10 @@ void QwtPlot::updateAxisEdgeMargin(QwtAxisId axisId)
     QRectF hostScaleRect = host->plotLayout()->scaleRect(axisId);
     // Host rectangle correction: only correct edgeMargin as the original rectangle
     hostScaleRect = shrinkRect(hostScaleRect, host->axisWidget(axisId)->edgeMargin(), axisId);
-    layers.append({ host, hostScaleRect });
+    AxisLayer hostLayer;
+    hostLayer.plot      = host;
+    hostLayer.scaleRect = hostScaleRect;
+    layers.append(hostLayer);
     // Parasite axes form levels 1, 2, ... in order of addition
     for (QwtPlot* p : parasites) {
         if (!p || !p->isAxisVisible(axisId)) {

--- a/src/plot/qwt_plot_boxchart.cpp
+++ b/src/plot/qwt_plot_boxchart.cpp
@@ -19,7 +19,11 @@
 #include "qwt_text.h"
 
 #include <qpainter.h>
+#if QT_VERSION >= QT_VERSION_CHECK(5, 10, 0)
 #include <qrandom.h>
+#else
+#include <qdatetime.h>
+#endif
 
 class QwtPlotBoxChart::PrivateData
 {
@@ -918,9 +922,14 @@ void QwtPlotBoxChart::drawOutliers(QPainter* painter,
     const bool doAlign           = QwtPainter::roundingAlignment(painter);
     const double jitter          = d->outlierJitter;
 
+#if QT_VERSION >= QT_VERSION_CHECK(5, 10, 0)
     QRandomGenerator* rng = nullptr;
     if (jitter > 0)
         rng = QRandomGenerator::global();
+#else
+    if (jitter > 0)
+        qsrand(static_cast<uint>(QTime::currentTime().msecsSinceStartOfDay()));
+#endif
 
     for (size_t i = 0; i < m_outlierData->size(); ++i) {
         const QwtBoxOutlierSample& outlierSample = m_outlierData->sample(i);
@@ -935,10 +944,18 @@ void QwtPlotBoxChart::drawOutliers(QPainter* painter,
                 valuePixel = qRound(valuePixel);
 
             double posPixel = basePosPixel;
+#if QT_VERSION >= QT_VERSION_CHECK(5, 10, 0)
             if (jitter > 0 && rng) {
                 const double offset = rng->bounded(jitter) - jitter * 0.5;
                 posPixel += offset;
             }
+#else
+            if (jitter > 0)
+            {
+                const double offset = (static_cast<double>(qrand()) / RAND_MAX) * jitter - jitter * 0.5;
+                posPixel += offset;
+            }
+#endif
 
             QPointF point = (orient == Qt::Vertical) ? QPointF(posPixel, valuePixel) : QPointF(valuePixel, posPixel);
 

--- a/src/plot/qwt_plot_canvas.h
+++ b/src/plot/qwt_plot_canvas.h
@@ -31,6 +31,7 @@
 #include "qwt_plot_abstract_canvas.h"
 
 #include <qframe.h>
+#include <qpainterpath.h>
 
 class QwtPlot;
 class QPixmap;

--- a/src/plot/qwt_plot_glcanvas.h
+++ b/src/plot/qwt_plot_glcanvas.h
@@ -31,6 +31,7 @@
 #include "qwt_plot_abstract_canvas.h"
 
 #include <qgl.h>
+#include <qpainterpath.h>
 
 class QwtPlot;
 

--- a/src/plot/qwt_plot_opengl_canvas.h
+++ b/src/plot/qwt_plot_opengl_canvas.h
@@ -35,6 +35,7 @@
 #include <QOpenGLWidget>
 #endif
 #include <QSurfaceFormat>
+#include <QPainterPath>
 
 class QwtPlot;
 

--- a/src/plot/qwt_plot_scale_event_dispatcher.cpp
+++ b/src/plot/qwt_plot_scale_event_dispatcher.cpp
@@ -401,7 +401,11 @@ bool QwtPlotScaleEventDispatcher::handleWheelEvent(QwtPlot* bindPlot, QWheelEven
     QwtScaleWidget* targetScale = findTargetOnScale(qwt::compat::eventPos(e));
     if (d->currentScale && d->currentScale == targetScale) {
         if (d->currentScale->testBuildinActions(QwtScaleWidget::ActionWheelZoom)) {
+#if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
             QPoint p = e->globalPosition().toPoint();
+#else
+            QPoint p = e->globalPos();
+#endif
             p        = d->currentScale->mapFromGlobal(p);
             if (qwt::compat::wheelEventDelta(e) > 0) {
                 d->currentPlot->zoomAxis(d->currentAxisId, d->zoomFactor, p);

--- a/xmake.lua
+++ b/xmake.lua
@@ -1,0 +1,22 @@
+add_rules("mode.debug", "mode.release")
+add_requires("opengl", "glu")
+
+target("qwt")
+    add_rules("qt.shared")
+    add_frameworks(
+        "QtWidgets", "QtGui", "QtCore", "QtSvg", "QtTest", 
+        "QtOpenGL", "QtPrintSupport", "QtConcurrent"
+    )
+    add_files("src/**.cpp")
+    add_files("src/**.c")
+    add_files("src/**.h")
+    add_headerfiles("(classincludes/**)", {prefixdir = "qwt"})
+    add_headerfiles("src/(**.h)", {prefixdir = "qwt"})
+    add_includedirs("src")
+    add_includedirs(os.dirs("src/**"))
+    add_defines("QWT_MAKEDLL", "QWT_DLL", "QWT3D_MAKEDLL", "QWT3D_DLL", "GL2PSDLL_EXPORTS", "GL2PSDLL")
+    if is_plat("windows") and is_mode("debug") then
+        set_suffixname("D")
+    end
+    add_packages("opengl", "glu")
+target_end()

--- a/xmake.lua
+++ b/xmake.lua
@@ -14,7 +14,12 @@ target("qwt")
     add_headerfiles("src/(**.h)", {prefixdir = "qwt"})
     add_includedirs("src")
     add_includedirs(os.dirs("src/**"))
-    add_defines("QWT_MAKEDLL", "QWT_DLL", "QWT3D_MAKEDLL", "QWT3D_DLL", "GL2PSDLL_EXPORTS", "GL2PSDLL")
+    add_defines(
+        "QWTCORE_MAKEDLL", "QWTCORE_DLL",
+        "QWT_MAKEDLL", "QWT_DLL", 
+        "QWT3D_MAKEDLL", "QWT3D_DLL", 
+        "GL2PSDLL_EXPORTS", "GL2PSDLL"
+    )
     if is_plat("windows") and is_mode("debug") then
         set_suffixname("D")
     end


### PR DESCRIPTION
# PR: QWT 多平台编译兼容性修复

## 概览

1. 兼容 Qt 5.7.1 ~ 5.15 的 API 变更（`Q_DECL_CONSTEXPR`、`QWheelEvent`、`QRandomGenerator`）
2. 补充间接引用但未显式包含的头文件（`QVector`、`QPainterPath`）
3. 添加 [xmake](https://xmake.io/zh/) 编译配置
4. 解决 GCC 15 + C++11（MinGW）及 MSVC 14.0（Qt 5.7.1）下的编译问题

## 编译问题与修复

### 1. `constexpr` 与 `Q_DECL_CONSTEXPR`

#### 问题 A：Qt 5.7.1 / MSVC 14.0

`QFlags` 在旧版 MSVC 中不是 literal type，导致 `constexpr` 函数编译失败：

```
src/core/qwt_interval.h(145): error C3615: constexpr 函数"QwtInterval::QwtInterval"不能生成常量表达式
src/core/qwt_interval.h(155): note: 失败原因是类型"QwtInterval::BorderFlags"不是有效的文本类型
qflags.h(92): note: 类型 "QFlags<QwtInterval::BorderFlag>" 不是文本类型，因为它不是聚合类型...
```

**涉及文件**：`qwt_interval.h`、`qwt_axis.h`、`qwt_scale_map.h`

**修复**：将 `constexpr` 替换为 Qt 提供的 `Q_DECL_CONSTEXPR` 宏。该宏在支持 `constexpr` 的编译器上展开为 `constexpr`，在不支持的编译器上展开为空，从而兼容各版本 Qt 和编译器。

#### 问题 B：GCC 15 + C++11（MinGW）

GCC 15 在 C++11 模式下存在 bug：当类有用户自定义的析构函数（及拷贝/移动特殊成员函数）时，编译器会**忽略类体内声明中的 `constexpr` 关键字**，但**保留类外定义中的 `constexpr`**，导致声明与定义的 `constexpr` 不一致：

```
error: redeclaration 'inline constexpr double QwtScaleMap::s1() const' differs in 'constexpr' from previous declaration
note: previous declaration 'constexpr double QwtScaleMap::s1() const'
```

复现条件：
- `-std=c++11`（项目在 mingw 下使用 C++11）
- 类有用户自定义析构函数（`QwtScaleMap` 有，`QwtInterval` 没有 → 不受影响）

**涉及文件**：`qwt_scale_map.h`

**修复**：将 8 个 `constexpr` 成员函数（`s1/s2/p1/p2/isLinear/isInverting/cnv/ts1`）及 `pDist/sDist` 的定义移入类体内。类内定义的 `constexpr` 在 GCC 15 C++11 下工作正常。

<mark>这个修复可能与项目的代码规范冲突，因为将内联函数移动到了类里面</mark>


### 2. Qt 5.10 `QRandomGenerator` API 兼容

`QRandomGenerator` 和 `<qrandom.h>` 在 Qt 5.10 引入，Qt 5.7.1 中不存在：

```
src/plot/qwt_plot_boxchart.cpp: fatal error: 'qrandom.h' file not found
```

**涉及文件**：`qwt_plot_boxchart.cpp`

**修复**：通过 `#if QT_VERSION >= QT_VERSION_CHECK(5, 10, 0)` 条件编译，Qt 5.10+ 使用 `QRandomGenerator::global()`，旧版回退到 `qsrand()` / `qrand()` + `<qdatetime.h>`。

### 3. Qt 5.15 `QWheelEvent::globalPosition()` API 兼容

`QWheelEvent::globalPosition()` 在 Qt 5.15 引入，替代了已废弃的 `globalPos()`：

```
src/plot/qwt_plot_scale_event_dispatcher.cpp: error: 'class QWheelEvent' has no member named 'globalPosition'
```

**涉及文件**：`qwt_plot_scale_event_dispatcher.cpp`

**修复**：通过 `#if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)` 条件编译，Qt 5.15+ 使用 `globalPosition().toPoint()`，旧版使用 `globalPos()`。

### 4. 缺失间接引用头文件

```
src/core/qwt_color_cycle.h(98): error C2079: "QwtColorCycle::m_colors"使用未定义的 class"QVector<QColor>"
```

另外 `QPainterPath` 在几个头文件中被间接使用但未显式包含，在部分 Qt 版本中会导致编译错误。

**涉及文件**：
- `qwt_color_cycle.h` — 添加 `#include <qvector.h>`
- `qwt_plot_canvas.h` — 添加 `#include <qpainterpath.h>`
- `qwt_plot_glcanvas.h` — 添加 `#include <qpainterpath.h>`
- `qwt_plot_opengl_canvas.h` — 添加 `#include <QPainterPath>`

### 5. `std::make_unique`（C++14 特性，C++11 不可用）

```
src/core/qwt_colormap_preset.cpp(225): error: 'make_unique' is not a member of 'std'
```

**涉及文件**：`qwt_colormap_preset.cpp`

**修复**：替换为 QWT 已有的 C++11 兼容版本 `qwt_make_unique`（定义于 `qwt_global.h`）。

### 6. 花括号初始化列表与 `QVector::append`

```
src/plot/qwt_plot.cpp(2132): error: no matching function for call to 'QVector<...>::append(<brace-enclosed initializer list>)'
```

C++11 中，局部结构体 `AxisLayer` 因有默认成员初始化器而非 aggregate，`append({...})` 的花括号初始化无效。

**涉及文件**：`qwt_plot.cpp`

**修复**：改为显式构造局部变量后 append。

## 变更文件清单

| 文件 | 变更类型 |
|------|----------|
| `src/core/qwt_interval.h` | `constexpr` → `Q_DECL_CONSTEXPR` |
| `src/core/qwt_scale_map.h` | 类内定义 + `Q_DECL_CONSTEXPR` |
| `src/core/qwt_color_cycle.h` | 补充 `#include <qvector.h>` |
| `src/core/qwt_colormap_preset.cpp` | `std::make_unique` → `qwt_make_unique` |
| `src/plot/qwt_axis.h` | `constexpr` → `Q_DECL_CONSTEXPR` |
| `src/plot/qwt_plot.cpp` | 修复 brace-init 兼容性 |
| `src/plot/qwt_plot_boxchart.cpp` | Qt 5.10 `QRandomGenerator` 条件编译 |
| `src/plot/qwt_plot_canvas.h` | 补充 `#include <qpainterpath.h>` |
| `src/plot/qwt_plot_glcanvas.h` | 补充 `#include <qpainterpath.h>` |
| `src/plot/qwt_plot_opengl_canvas.h` | 补充 `#include <QPainterPath>` |
| `src/plot/qwt_plot_scale_event_dispatcher.cpp` | Qt 5.15 `globalPosition()` 条件编译 |
| `xmake.lua` | 新增 xmake 构建配置 |

## 测试平台

| 平台 | 编译器 | Qt 版本 | 状态 |
|------|--------|---------|------|
| Windows (MinGW) | GCC 15.2.0 | 5.15.2 | ✅ |
| Windows (MSVC) | MSVC 14.0 | 5.7.1 | ✅ |
| Windows (MSVC) | MSVC 19.x | 5.15.2 | ✅ |
